### PR TITLE
Add new argument to magic_cb to send the thread id

### DIFF
--- a/target-arm/helper.c
+++ b/target-arm/helper.c
@@ -881,8 +881,8 @@ static void pmcr_write(CPUARMState *env, const ARMCPRegInfo *ri,
                 printf("for pid %" PRIu64 " on core %d.\n", qsim_tpid, qsim_id);
 
             // Call magic cb the first time
-            if (qsim_magic_cb && qsim_magic_cb(qsim_id, value)) {
-                qsim_swap_ctx();
+            if (qsim_magic_cb && qsim_magic_cb(qsim_id, value, 0)) { // 0 in the 3rd argument of qsim_magic_cb represents
+                qsim_swap_ctx();                                     // the ebx but is not needed in case of arm
             }
         }
         qsim_gen_callbacks++;
@@ -895,11 +895,11 @@ static void pmcr_write(CPUARMState *env, const ARMCPRegInfo *ri,
           printf("Disabling callback generation\n");
 
           // Call magic cb the last time
-          if (qsim_magic_cb && qsim_magic_cb(qsim_id, value)) {
+          if (qsim_magic_cb && qsim_magic_cb(qsim_id, value, 0)) {
               qsim_swap_ctx();
           }
       }
-    } else if (qsim_magic_cb && qsim_magic_cb(qsim_id, value)) {
+    } else if (qsim_magic_cb && qsim_magic_cb(qsim_id, value, 0)) {
         qsim_swap_ctx();
     }
 

--- a/target-i386/misc_helper.c
+++ b/target-i386/misc_helper.c
@@ -184,7 +184,7 @@ void helper_cpuid(CPUX86State *env)
             else
                 printf("for pid %" PRIu64 " on core %d.\n", qsim_tpid, cpu_id);
 
-            if (qsim_magic_cb && qsim_magic_cb(cpu_id, env->regs[R_EAX]))
+            if (qsim_magic_cb && qsim_magic_cb(cpu_id, env->regs[R_EAX], env->regs[R_EBX]))
                 qsim_swap_ctx();
         }
         qsim_gen_callbacks++;
@@ -196,10 +196,10 @@ void helper_cpuid(CPUX86State *env)
 
             printf("Disabling callback generation.\n");
 
-            if (qsim_magic_cb && qsim_magic_cb(cpu_id, env->regs[R_EAX]))
+            if (qsim_magic_cb && qsim_magic_cb(cpu_id, env->regs[R_EAX], env->regs[R_EBX]))
                 qsim_swap_ctx();
         }
-    } else if (qsim_magic_cb && qsim_magic_cb(cpu_id, env->regs[R_EAX]))
+    } else if (qsim_magic_cb && qsim_magic_cb(cpu_id, env->regs[R_EAX], env->regs[R_EBX]))
         qsim_swap_ctx();
 
     if ((eax & 0xffff0000) == 0xc75c0000) {

--- a/vl.c
+++ b/vl.c
@@ -2085,7 +2085,7 @@ static void qsim_loop_main(void)
 
     // send shutdown signal
     if (qsim_magic_cb)
-        qsim_magic_cb(0, 0xfa11dead);
+        qsim_magic_cb(0, 0xfa11dead, 0x00000000);
 
     return;
 }


### PR DESCRIPTION
This adds the functionality of allowing the qsim backend to get the thread ID of the process running on a core. This allows us to differentiate between different threads of a multithreaded program.